### PR TITLE
Release Workflow Bug Fix for r0adkll/sign-android-release

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -32,6 +32,13 @@ jobs:
       - name: Build APK
         run: bash ./gradlew assembleRelease
 
+      - name: Get Build Tool Version
+        shell: bash
+        run: |
+          BUILD_TOOL_VERSION=$(ls /usr/local/lib/android/sdk/build-tools/ | tail -n 1)
+          echo "BUILD_TOOL_VERSION=$BUILD_TOOL_VERSION" >> $GITHUB_ENV
+          echo Last build tool version is: $BUILD_TOOL_VERSION
+
       # https://github.com/marketplace/actions/sign-android-release
       - name: Sign APK
         id: sign_apk
@@ -42,6 +49,8 @@ jobs:
           alias: ${{ secrets.ALIAS }}
           keyStorePassword: ${{ secrets.KEY_STORE_PASSWORD }}
           keyPassword: ${{ secrets.KEY_PASSWORD }}
+        env:
+          BUILD_TOOLS_VERSION: ${{ env.BUILD_TOOL_VERSION }}
 
       # https://github.com/marketplace/actions/auto-changelog
       # require commit format are "type(category): description [flag]"


### PR DESCRIPTION
<!-- 感谢您的贡献！ -->
<!-- Thanks for your contribution! -->

### 类型 / Type

- [ ] 新特性 New feature
- [x] 问题修复 Bug fix
- [ ] 编码风格优化 Code style optimization
- [ ] 文档更新 documentation update
- [ ] 依赖更新 Dependencies update
- [ ] 性能优化 Performance optimization
- [ ] 功能增加 Enhancement function
- [ ] 其他 Other (about what?)

<!-- 请选择该 PR 的类型。 -->
<!-- Please select your PR’s type. -->

### 描述 / Description

`r0adkll/sign-android-release` has some broken features and this PR is to fix those, as suggested in the [Original Issue](https://github.com/r0adkll/sign-android-release/issues/84). The bug is related to setting the default version of the build tools for the code signing toolkit.

Error message without it:
```
Error: Couldnt find the Android build tools @ /usr/local/lib/android/sdk/build-tools/30.0.2
Error: Unable to locate executable file: /usr/local/lib/android/sdk/build-tools/30.0.2/zipalign. Please verify either the file path exists or the file can be found within a directory specified by the PATH environment variable. Also check the file mode to verify the file is executable.
```

<!-- 请在上面详细描述该 PR 的实现原理。 -->
<!-- Please describe the principles of implementing. -->

### 相关 ISSUE / Related ISSUE

[Original Issue](https://github.com/r0adkll/sign-android-release/issues/84)

<!-- 请在上面添加相关 ISSUE 的链接。 -->
<!-- Add the links of related issue. -->

### 合并检测 / Merge Check

<!-- 合并 PR 时，检查下面的工作是否完成。（提交 PR 时无需关心） -->
<!-- Check blow items, when merge this PR. (DO NOT CARE when submit your PR) -->

- [ ] 文档是否更新 If document is updated or not
- [ ] 变更记录是否记录 If changelog is updated or not
