### PR TITLE
Fix wrong name recorded when adding coordinates manually

### DIFF
--- a/app/src/main/java/com/zcshou/gogogo/MainActivity.java
+++ b/app/src/main/java/com/zcshou/gogogo/MainActivity.java
@@ -908,6 +908,7 @@ public class MainActivity extends BaseActivity implements SensorEventListener {
                                 mMarkLatLngMap = new LatLng(bdLonLat[1], bdLonLat[0]);
                             }
                             markMap();
+                            mMarkName = "手动输入的坐标";
 
                             MapStatusUpdate mapstatusupdate = MapStatusUpdateFactory.newLatLng(mMarkLatLngMap);
                             mBaiduMap.setMapStatus(mapstatusupdate);


### PR DESCRIPTION
<!-- 感谢您的贡献！ -->
<!-- Thanks for your contribution! -->

### 类型 / Type

- [ ] 新特性 New feature
- [x] 问题修复 Bug fix
- [ ] 编码风格优化 Code style optimization
- [ ] 文档更新 documentation update
- [ ] 依赖更新 Dependencies update
- [ ] 性能优化 Performance optimization
- [ ] 功能增加 Enhancement function
- [ ] 其他 Other (about what?)

<!-- 请选择该 PR 的类型。 -->
<!-- Please select your PR’s type. -->

### 描述 / Description
`markMap` 函数中会将 `mMarkName` 置为null，导致 `mMarkName = "手动输入的坐标"` 失效 
进而导致在某些情况下保存地点时名称可能来自上次选择的历史记录的名称


<!-- 请在上面详细描述该 PR 的实现原理。 -->
<!-- Please describe the principles of implementing. -->

### 相关 ISSUE / Related ISSUE



<!-- 请在上面添加相关 ISSUE 的链接。 -->
<!-- Add the links of related issue. -->

### 合并检测 / Merge Check

<!-- 合并 PR 时，检查下面的工作是否完成。（提交 PR 时无需关心） -->
<!-- Check blow items, when merge this PR. (DO NOT CARE when submit your PR) -->

- [ ] 文档是否更新 If document is updated or not
- [ ] 变更记录是否记录 If changelog is updated or not
