### PR TITLE
fix:search logic flaw about keyword matching in string

### DIFF
--- a/app/src/main/java/com/zcshou/gogogo/HistoryActivity.java
+++ b/app/src/main/java/com/zcshou/gogogo/HistoryActivity.java
@@ -232,7 +232,7 @@ public class HistoryActivity extends BaseActivity {
                 } else {
                     List<Map<String, Object>> searchRet = new ArrayList<>();
                     for (int i = 0; i < mAllRecord.size(); i++){
-                        if (mAllRecord.get(i).toString().indexOf(newText) > 0){
+                        if (mAllRecord.get(i).toString().indexOf(newText) >= 0){
                             searchRet.add(mAllRecord.get(i));
                         }
                     }

--- a/app/src/main/java/com/zcshou/joystick/JoyStick.java
+++ b/app/src/main/java/com/zcshou/joystick/JoyStick.java
@@ -692,7 +692,7 @@ public class JoyStick extends View {
                 } else {
                     List<Map<String, Object>> searchRet = new ArrayList<>();
                     for (int i = 0; i < mAllRecord.size(); i++){
-                        if (mAllRecord.get(i).toString().indexOf(newText) > 0){
+                        if (mAllRecord.get(i).toString().indexOf(newText) >= 0){
                             searchRet.add(mAllRecord.get(i));
                         }
                     }


### PR DESCRIPTION
<!-- 感谢您的贡献！ -->
<!-- Thanks for your contribution! -->

### 类型 / Type

- [ ] 新特性 New feature
- [x] 问题修复 Bug fix
- [ ] 编码风格优化 Code style optimization
- [ ] 文档更新 documentation update
- [ ] 依赖更新 Dependencies update
- [ ] 性能优化 Performance optimization
- [ ] 功能增加 Enhancement function
- [x] 其他 Other (about what?)

<!-- 请选择该 PR 的类型。 -->
<!-- Please select your PR’s type. -->

### 描述 / Description

当搜索关键词出现在字符串开头（如"北京"的位置记录），`indexOf()` 返回0，但条件 `> 0` 会过滤掉它，导致无法搜索到

<!-- 请在上面详细描述该 PR 的实现原理。 -->
<!-- Please describe the principles of implementing. -->

### 相关 ISSUE / Related ISSUE



<!-- 请在上面添加相关 ISSUE 的链接。 -->
<!-- Add the links of related issue. -->

### 合并检测 / Merge Check

<!-- 合并 PR 时，检查下面的工作是否完成。（提交 PR 时无需关心） -->
<!-- Check blow items, when merge this PR. (DO NOT CARE when submit your PR) -->

- [ ] 文档是否更新 If document is updated or not
- [ ] 变更记录是否记录 If changelog is updated or not
